### PR TITLE
Fix install target and add cpack support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,3 +64,7 @@ include(CTest)
 
 add_subdirectory(src)
 add_subdirectory(benchmarks)
+
+set(CPACK_GENERATOR "TGZ")
+set(CPACK_PACKAGE_FILE_NAME "distributions")
+include(CPack)

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ install_cy: $(install_cy_deps) FORCE
 
 install: install_cc install_cy FORCE
 
+package: build_cc FORCE
+	cd build && $(MAKE) package
+
 install_cc_examples: install_cc FORCE
 
 test_cc_examples: install_cc_examples FORCE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,8 +10,15 @@ set(DISTRIBUTIONS_SOURCE_FILES
   models/gp.cc
 )
 
+install(DIRECTORY ../include/ DESTINATION include
+  FILES_MATCHING PATTERN "*.h*")
+
 if(PROTOBUF_FOUND)
   set(DISTRIBUTIONS_SOURCE_FILES io/schema.pb.cc ${DISTRIBUTIONS_SOURCE_FILES})
+  install(DIRECTORY ../distributions/ DESTINATION include/distributions
+    FILES_MATCHING PATTERN "*.proto")
+  install(DIRECTORY ../include/ DESTINATION include
+    FILES_MATCHING PATTERN "*.cc")
 endif()
 
 add_library(distributions_shared SHARED ${DISTRIBUTIONS_SOURCE_FILES})


### PR DESCRIPTION
This supports internal packaging efforts and also make distributions behave more like a real library.
