### PR TITLE
forgot to add distributions.vendor package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ config = {
         'distributions.lp.models',
         'distributions.io',
         'distributions.tests',
+        'distributions.vendor',
     ],
     'ext_modules': ext_modules,
 }


### PR DESCRIPTION
tests don't catch this because they run from the source tree
