### PR TITLE
Don't link distributions against itself.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.6)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 project(distributions)
-set(DISTRIBUTIONS_SHARED_LIBS distributions_shared m)
+set(DISTRIBUTIONS_SHARED_LIBS m)
 
 if(APPLE)
   # for anaconda builds

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,26 +1,16 @@
 include_directories(../include)
 
 add_executable(sample_from_scores sample_from_scores.cc)
-target_link_libraries(sample_from_scores
-  ${DISTRIBUTIONS_SHARED_LIBS}
-)
+target_link_libraries(sample_from_scores distributions_shared)
 
 add_executable(sample_assignment_from_py sample_assignment_from_py.cc)
-target_link_libraries(sample_assignment_from_py
-  ${DISTRIBUTIONS_SHARED_LIBS}
-)
+target_link_libraries(sample_assignment_from_py distributions_shared)
 
 add_executable(score_counts score_counts.cc)
-target_link_libraries(score_counts
-  ${DISTRIBUTIONS_SHARED_LIBS}
-)
+target_link_libraries(score_counts distributions_shared)
 
 add_executable(special special.cc)
-target_link_libraries(special
-  ${DISTRIBUTIONS_SHARED_LIBS}
-)
+target_link_libraries(special distributions_shared)
 
 add_executable(mixture mixture.cc)
-target_link_libraries(mixture
-  ${DISTRIBUTIONS_SHARED_LIBS}
-)
+target_link_libraries(mixture distributions_shared)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,10 +28,10 @@ install(TARGETS distributions_shared LIBRARY DESTINATION lib)
 
 add_executable(test_headers_shared test_headers.cc)
 add_test(test_headers_shared test_headers_shared)
-target_link_libraries(test_headers_shared ${DISTRIBUTIONS_SHARED_LIBS})
+target_link_libraries(test_headers_shared distributions_shared)
 
 if(PROTOBUF_FOUND)
   add_executable(test_protobuf_shared test_protobuf.cc)
   add_test(test_protobuf_shared test_protobuf_shared)
-  target_link_libraries(test_protobuf_shared ${DISTRIBUTIONS_SHARED_LIBS})
+  target_link_libraries(test_protobuf_shared distributions_shared)
 endif()


### PR DESCRIPTION
DISTRIBUTIONS_SHARED_LIBS was used for two things: the libraries to link
to libdistributions, and the libraries to link to programs using
libdistributions. Now it is only the libraries to link to
libdistributions; programs using libdistributions link to
libdistributions and get its dependencies automatically.
